### PR TITLE
Add buffer_type enum and simply flipBuffers code

### DIFF
--- a/include/Console.hpp
+++ b/include/Console.hpp
@@ -74,24 +74,9 @@ namespace Blame {
         void flipBuffers() {
             this->has_flipped.exchange(true);
 
-            switch (this->current_buffer) {
-                case 0:
-                    std::cout << back_buffer.str();
-                    // Clear the buffer
-                    back_buffer.str(std::string());
-                    this->current_buffer = 1;
-                    break;
-
-                case 1:
-                    std::cout << front_buffer.str();
-                    // Clear the buffer
-                    front_buffer.str(std::string());
-                    this->current_buffer = 0;
-                    break;
-
-                default:
-                    break;
-            }
+            this->current_buffer = static_cast<buffer_t>((this->current_buffer + 1) % NUM_BUFFERS);
+            std::cout << buffer_list.at(this->current_buffer)->str();
+            buffer_list.at(this->current_buffer)->str(std::string());
 
             // this->setTitle(std::to_string(this->current_buffer));
         }
@@ -105,10 +90,13 @@ namespace Blame {
         std::vector<Blame::Widgets::Listener *> focus_order;
         Blame::Widgets::Listener *focused_widget;
 
+        enum buffer_t {
+          FRONT=0, BACK, NUM_BUFFERS
+        };
         std::ostringstream front_buffer;
         std::ostringstream back_buffer;
         std::vector<std::ostringstream *> buffer_list;
-        int current_buffer = 0;
+        buffer_t current_buffer = FRONT;
 
         std::atomic_bool has_flipped;
 

--- a/include/Console.hpp
+++ b/include/Console.hpp
@@ -93,8 +93,8 @@ namespace Blame {
         enum buffer_t {
           FRONT=0, BACK, NUM_BUFFERS
         };
-        std::ostringstream front_buffer;
-        std::ostringstream back_buffer;
+/*        std::ostringstream front_buffer;
+        std::ostringstream back_buffer;*/
         std::vector<std::ostringstream *> buffer_list;
         buffer_t current_buffer = FRONT;
 

--- a/src/main/cpp/Console.cpp
+++ b/src/main/cpp/Console.cpp
@@ -17,8 +17,10 @@ Blame::Console::Console() {
     this->moveCaret(std::cout, 0, 0);
     std::cout << Blame::Util::EscapeCodes::caretOff();
 
-    this->buffer_list.push_back(&front_buffer);
-    this->buffer_list.push_back(&back_buffer);
+    std::ostringstream *front_buffer = new std::ostringstream();
+    std::ostringstream *back_buffer = new std::ostringstream();
+    this->buffer_list.push_back(front_buffer);
+    this->buffer_list.push_back(back_buffer);
 
     this->exit.store(false);
     this->has_flipped.store(true);
@@ -58,6 +60,11 @@ Blame::Console::~Console() {
     term.c_lflag |= ECHO;
     term.c_lflag |= ICANON;
     tcsetattr(STDIN_FILENO, TCSANOW, &term);
+
+    /* TODO We still need to delete all the manually-allocated memory.
+     * Right?*/
+    delete buffer_list.at(FRONT);
+    delete buffer_list.at(BACK);
 }
 
 void Blame::Console::mainLoop() {


### PR DESCRIPTION
This new addition simplifies the code in the flipBuffers() method, using a new
enum to capture the FRONT and BACK buffers in effect at a given time. It also
uses fewer lines, at the cost of using a static_cast.